### PR TITLE
LXDProfile: Don't apply when not provisioned

### DIFF
--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -138,6 +138,14 @@ func findDNSServerConfig() (*network.DNSConfig, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		// network.ParseResolvConf returns nil error and nil dnsConfig if the
+		// file isn't found, which can lead to a panic when attemptting to
+		// access the dnsConfig.Nameservers. So instead, just continue and
+		// exhaust the resolvConfFiles slice.
+		if dnsConfig == nil {
+			logger.Tracef("The DNS configuration from %s returned no dnsConfig")
+			continue
+		}
 		for _, nameServer := range dnsConfig.Nameservers {
 			if nameServer.Scope != network.ScopeMachineLocal {
 				logger.Debugf("The DNS configuration from %s has been selected for use", dnsConfigFile)


### PR DESCRIPTION
The following changes ensure that we don't attempt to apply a
charm profile to a machine that isn't either running or that isn't
provisioned.

Interestingly the charm profile will be written later on when ensuring
that the profile is there, by the provisioner API. So we don't have
to write any other code that to stop the applying of the charm
profile.

 - Add tests around provisioner task