### PR TITLE
feat: resource store type

### DIFF
--- a/apiserver/facades/controller/cleaner/cleaner_test.go
+++ b/apiserver/facades/controller/cleaner/cleaner_test.go
@@ -52,10 +52,11 @@ func (s *CleanerSuite) SetUpTest(c *gc.C) {
 	res := common.NewResources()
 	s.machineService = machineservice.NewWatchableService(nil, nil, nil)
 	s.applicationService = applicationservice.NewWatchableService(
-		nil, nil, nil, nil, "", nil, nil,
+		nil, nil, nil, nil, nil, "", nil, nil,
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return storage.NotImplementedProviderRegistry{}
 		}),
+		nil,
 		loggertesting.WrapCheckLog(c),
 	)
 

--- a/domain/application/modelmigration/export.go
+++ b/domain/application/modelmigration/export.go
@@ -78,9 +78,13 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 		state.NewApplicationState(scope.ModelDB(), e.logger),
 		NoopDeleteSecretState{},
 		state.NewCharmState(scope.ModelDB()),
+		state.NewResourceState(scope.ModelDB(), e.logger),
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return storage.NotImplementedProviderRegistry{}
 		}),
+		// TODO: Wire through an objectstoreGetter when implementing
+		// model migration for resources if needed.
+		nil,
 		e.logger,
 	)
 	return nil

--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -74,7 +74,11 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 		state.NewApplicationState(scope.ModelDB(), i.logger),
 		NoopDeleteSecretState{},
 		state.NewCharmState(scope.ModelDB()),
+		state.NewResourceState(scope.ModelDB(), i.logger),
 		i.registry,
+		// TODO: Wire through an objectstoreGetter when implementing
+		// model migration for resources if needed.
+		nil,
 		i.logger,
 	)
 	return nil

--- a/domain/application/resource/store.go
+++ b/domain/application/resource/store.go
@@ -1,0 +1,55 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/internal/charm/resource"
+)
+
+type ResourceStore interface {
+	// Get returns an io.ReadCloser for data at path, namespaced to the
+	// model.
+	Get(context.Context, string) (io.ReadCloser, int64, error)
+}
+
+type OCIResourceStore struct {
+}
+
+func (f OCIResourceStore) Get(ctx context.Context, path string) (io.ReadCloser, int64, error) {
+	return nil, -1, nil
+}
+
+type FileResourceStore struct {
+	objectStore objectstore.ObjectStore
+}
+
+func (f FileResourceStore) Get(ctx context.Context, path string) (io.ReadCloser, int64, error) {
+	return f.objectStore.Get(ctx, path)
+}
+
+type ResourceStoreFactory struct {
+	objectStore objectstore.ModelObjectStoreGetter
+}
+
+func NewResourceStoreFactory(objectStore objectstore.ModelObjectStoreGetter) ResourceStoreFactory {
+	return ResourceStoreFactory{objectStore: objectStore}
+}
+
+func (f ResourceStoreFactory) GetResourceStore(ctx context.Context, t resource.Type) (ResourceStore, error) {
+	switch t {
+	case resource.TypeContainerImage:
+		return OCIResourceStore{}, nil
+	case resource.TypeFile:
+		objectstore, err := f.objectStore.GetObjectStore(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return FileResourceStore{objectStore: objectstore}, nil
+	default:
+		return nil, fmt.Errorf("unknown resource type %q", t)
+	}
+}

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -11,7 +11,6 @@ package service
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
 	application "github.com/juju/juju/core/application"
@@ -2270,82 +2269,80 @@ func (c *MockResourceStateListResourcesCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
-// OpenResource mocks base method.
-func (m *MockResourceState) OpenResource(arg0 context.Context, arg1 resources.ID) (resource.Resource, io.ReadCloser, error) {
+// OpenApplicationResource mocks base method.
+func (m *MockResourceState) OpenApplicationResource(arg0 context.Context, arg1 resources.ID) (resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenResource", arg0, arg1)
+	ret := m.ctrl.Call(m, "OpenApplicationResource", arg0, arg1)
 	ret0, _ := ret[0].(resource.Resource)
-	ret1, _ := ret[1].(io.ReadCloser)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// OpenResource indicates an expected call of OpenResource.
-func (mr *MockResourceStateMockRecorder) OpenResource(arg0, arg1 any) *MockResourceStateOpenResourceCall {
+// OpenApplicationResource indicates an expected call of OpenApplicationResource.
+func (mr *MockResourceStateMockRecorder) OpenApplicationResource(arg0, arg1 any) *MockResourceStateOpenApplicationResourceCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenResource", reflect.TypeOf((*MockResourceState)(nil).OpenResource), arg0, arg1)
-	return &MockResourceStateOpenResourceCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenApplicationResource", reflect.TypeOf((*MockResourceState)(nil).OpenApplicationResource), arg0, arg1)
+	return &MockResourceStateOpenApplicationResourceCall{Call: call}
 }
 
-// MockResourceStateOpenResourceCall wrap *gomock.Call
-type MockResourceStateOpenResourceCall struct {
+// MockResourceStateOpenApplicationResourceCall wrap *gomock.Call
+type MockResourceStateOpenApplicationResourceCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockResourceStateOpenResourceCall) Return(arg0 resource.Resource, arg1 io.ReadCloser, arg2 error) *MockResourceStateOpenResourceCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockResourceStateOpenApplicationResourceCall) Return(arg0 resource.Resource, arg1 error) *MockResourceStateOpenApplicationResourceCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceStateOpenResourceCall) Do(f func(context.Context, resources.ID) (resource.Resource, io.ReadCloser, error)) *MockResourceStateOpenResourceCall {
+func (c *MockResourceStateOpenApplicationResourceCall) Do(f func(context.Context, resources.ID) (resource.Resource, error)) *MockResourceStateOpenApplicationResourceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceStateOpenResourceCall) DoAndReturn(f func(context.Context, resources.ID) (resource.Resource, io.ReadCloser, error)) *MockResourceStateOpenResourceCall {
+func (c *MockResourceStateOpenApplicationResourceCall) DoAndReturn(f func(context.Context, resources.ID) (resource.Resource, error)) *MockResourceStateOpenApplicationResourceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// OpenResourceForUniter mocks base method.
-func (m *MockResourceState) OpenResourceForUniter(arg0 context.Context, arg1 resources.ID, arg2 unit.UUID) (resource.Resource, io.ReadCloser, error) {
+// OpenUnitResource mocks base method.
+func (m *MockResourceState) OpenUnitResource(arg0 context.Context, arg1 resources.ID, arg2 unit.UUID) (resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenResourceForUniter", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "OpenUnitResource", arg0, arg1, arg2)
 	ret0, _ := ret[0].(resource.Resource)
-	ret1, _ := ret[1].(io.ReadCloser)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// OpenResourceForUniter indicates an expected call of OpenResourceForUniter.
-func (mr *MockResourceStateMockRecorder) OpenResourceForUniter(arg0, arg1, arg2 any) *MockResourceStateOpenResourceForUniterCall {
+// OpenUnitResource indicates an expected call of OpenUnitResource.
+func (mr *MockResourceStateMockRecorder) OpenUnitResource(arg0, arg1, arg2 any) *MockResourceStateOpenUnitResourceCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenResourceForUniter", reflect.TypeOf((*MockResourceState)(nil).OpenResourceForUniter), arg0, arg1, arg2)
-	return &MockResourceStateOpenResourceForUniterCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenUnitResource", reflect.TypeOf((*MockResourceState)(nil).OpenUnitResource), arg0, arg1, arg2)
+	return &MockResourceStateOpenUnitResourceCall{Call: call}
 }
 
-// MockResourceStateOpenResourceForUniterCall wrap *gomock.Call
-type MockResourceStateOpenResourceForUniterCall struct {
+// MockResourceStateOpenUnitResourceCall wrap *gomock.Call
+type MockResourceStateOpenUnitResourceCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockResourceStateOpenResourceForUniterCall) Return(arg0 resource.Resource, arg1 io.ReadCloser, arg2 error) *MockResourceStateOpenResourceForUniterCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockResourceStateOpenUnitResourceCall) Return(arg0 resource.Resource, arg1 error) *MockResourceStateOpenUnitResourceCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceStateOpenResourceForUniterCall) Do(f func(context.Context, resources.ID, unit.UUID) (resource.Resource, io.ReadCloser, error)) *MockResourceStateOpenResourceForUniterCall {
+func (c *MockResourceStateOpenUnitResourceCall) Do(f func(context.Context, resources.ID, unit.UUID) (resource.Resource, error)) *MockResourceStateOpenUnitResourceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceStateOpenResourceForUniterCall) DoAndReturn(f func(context.Context, resources.ID, unit.UUID) (resource.Resource, io.ReadCloser, error)) *MockResourceStateOpenResourceForUniterCall {
+func (c *MockResourceStateOpenUnitResourceCall) DoAndReturn(f func(context.Context, resources.ID, unit.UUID) (resource.Resource, error)) *MockResourceStateOpenUnitResourceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/resource_test.go
+++ b/domain/application/service/resource_test.go
@@ -302,6 +302,6 @@ func (s *resourceServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.state = NewMockResourceState(ctrl)
-	s.service = NewResourceService(s.state, loggertesting.WrapCheckLog(c))
+	s.service = NewResourceService(s.state, nil, loggertesting.WrapCheckLog(c))
 	return ctrl
 }

--- a/domain/application/service/resource_test.go
+++ b/domain/application/service/resource_test.go
@@ -219,28 +219,28 @@ func (s *resourceServiceSuite) TestSetUnitResource(c *gc.C) {
 	c.Assert(obtainedRet, gc.DeepEquals, expectedRet)
 }
 
-func (s *resourceServiceSuite) TestOpenResource(c *gc.C) {
+func (s *resourceServiceSuite) TestOpenApplicationResource(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	id := resourcestesting.GenResourceID(c)
 	expectedRes := resource.Resource{
 		ID:            id,
 		ApplicationID: applicationtesting.GenApplicationUUID(c),
 	}
-	s.state.EXPECT().OpenResource(gomock.Any(), id).Return(expectedRes, nil, nil)
+	s.state.EXPECT().OpenApplicationResource(gomock.Any(), id).Return(expectedRes, nil)
 
-	obtainedRes, _, err := s.service.OpenResource(context.Background(), id)
+	obtainedRes, _, err := s.service.OpenApplicationResource(context.Background(), id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedRes, gc.DeepEquals, obtainedRes)
 }
 
-func (s *resourceServiceSuite) TestOpenResourceBadID(c *gc.C) {
+func (s *resourceServiceSuite) TestOpenApplicationResourceBadID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, _, err := s.service.OpenResource(context.Background(), "id")
+	_, _, err := s.service.OpenApplicationResource(context.Background(), "id")
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
-func (s *resourceServiceSuite) TestOpenResourceForUniter(c *gc.C) {
+func (s *resourceServiceSuite) TestOpenUnitResource(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	resourceID := resourcestesting.GenResourceID(c)
 	unitID := unittesting.GenUnitUUID(c)
@@ -248,26 +248,26 @@ func (s *resourceServiceSuite) TestOpenResourceForUniter(c *gc.C) {
 		ID:            resourceID,
 		ApplicationID: applicationtesting.GenApplicationUUID(c),
 	}
-	s.state.EXPECT().OpenResourceForUniter(gomock.Any(), resourceID, unitID).Return(expectedRes, nil, nil)
+	s.state.EXPECT().OpenUnitResource(gomock.Any(), resourceID, unitID).Return(expectedRes, nil)
 
-	obtainedRes, _, err := s.service.OpenResourceForUniter(context.Background(), resourceID, unitID)
+	obtainedRes, _, err := s.service.OpenUnitResource(context.Background(), resourceID, unitID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedRes, gc.DeepEquals, obtainedRes)
 
 }
 
-func (s *resourceServiceSuite) TestOpenResourceForUniterBadUnitID(c *gc.C) {
+func (s *resourceServiceSuite) TestOpenUnitResourceBadUnitID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	resourceID := resourcestesting.GenResourceID(c)
 
-	_, _, err := s.service.OpenResourceForUniter(context.Background(), resourceID, "")
+	_, _, err := s.service.OpenUnitResource(context.Background(), resourceID, "")
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
-func (s *resourceServiceSuite) TestOpenResourceForUniterBadResourceID(c *gc.C) {
+func (s *resourceServiceSuite) TestOpenUnitResourceBadResourceID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, _, err := s.service.OpenResourceForUniter(context.Background(), "", "")
+	_, _, err := s.service.OpenUnitResource(context.Background(), "", "")
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/providertracker"
 	corestorage "github.com/juju/juju/core/storage"
 	"github.com/juju/juju/core/watcher"
@@ -37,13 +36,13 @@ func NewService(
 	charmSt CharmState,
 	resourceSt ResourceState,
 	storageRegistryGetter corestorage.ModelStorageRegistryGetter,
-	objectstoreGetter objectstore.ModelObjectStoreGetter,
+	resourceStoreGetter ResourceStoreGetter,
 	logger logger.Logger,
 ) *Service {
 	return &Service{
 		ApplicationService: NewApplicationService(appSt, deleteSecretSt, storageRegistryGetter, logger),
 		CharmService:       NewCharmService(charmSt, logger),
-		ResourceService:    NewResourceService(resourceSt, objectstoreGetter, logger),
+		ResourceService:    NewResourceService(resourceSt, resourceStoreGetter, logger),
 	}
 }
 
@@ -66,7 +65,7 @@ func NewWatchableService(
 	agentVersionGetter AgentVersionGetter,
 	provider providertracker.ProviderGetter[Provider],
 	storageRegistryGetter corestorage.ModelStorageRegistryGetter,
-	objectstoreGetter objectstore.ModelObjectStoreGetter,
+	resourceStoreGetter ResourceStoreGetter,
 	logger logger.Logger,
 ) *WatchableService {
 	watchableCharmService := NewWatchableCharmService(charmSt, watcherFactory, logger)
@@ -76,7 +75,7 @@ func NewWatchableService(
 		Service: Service{
 			CharmService:       &watchableCharmService.CharmService,
 			ApplicationService: &watchableApplicationService.ApplicationService,
-			ResourceService:    NewResourceService(resourceSt, objectstoreGetter, logger),
+			ResourceService:    NewResourceService(resourceSt, resourceStoreGetter, logger),
 		},
 		watchableCharmService:       watchableCharmService,
 		watchableApplicationService: watchableApplicationService,

--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -61,9 +61,13 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 			loggertesting.WrapCheckLog(c),
 		),
 		state.NewCharmState(func() (database.TxnRunner, error) { return s.ModelTxnRunner(), nil }),
+		state.NewResourceState(func() (database.TxnRunner, error) { return s.ModelTxnRunner(), nil },
+			loggertesting.WrapCheckLog(c),
+		),
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return provider.CommonStorageProviders()
 		}),
+		nil,
 		loggertesting.WrapCheckLog(c),
 	)
 

--- a/domain/application/state/resource.go
+++ b/domain/application/state/resource.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/resources"
+	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/application/resource"
+)
+
+// ResourceState is used to access the database.
+type ResourceState struct {
+	*commonStateBase
+	logger logger.Logger
+}
+
+// NewResourceState creates a state to access the database.
+func NewResourceState(factory database.TxnRunnerFactory, logger logger.Logger) *ResourceState {
+	return &ResourceState{
+		commonStateBase: &commonStateBase{
+			StateBase: domain.NewStateBase(factory),
+		},
+		logger: logger,
+	}
+}
+
+// GetApplicationResourceID returns the ID of the application resource
+// specified by natural key of application and resource name.
+func (st *ResourceState) GetApplicationResourceID(ctx context.Context, args resource.GetApplicationResourceIDArgs) (resources.ID, error) {
+	return "", nil
+}
+
+// ListResources returns the list of resources for the given application.
+func (st *ResourceState) ListResources(ctx context.Context, applicationID application.ID) (resource.ApplicationResources, error) {
+	return resource.ApplicationResources{}, nil
+}
+
+// GetResource returns the identified resource.
+func (st *ResourceState) GetResource(ctx context.Context, resourceID resources.ID) (resource.Resource, error) {
+	return resource.Resource{}, nil
+}
+
+// SetResource adds the resource to blob storage and updates the metadata.
+func (st *ResourceState) SetResource(ctx context.Context, config resource.SetResourceArgs) (resource.Resource, error) {
+	return resource.Resource{}, nil
+}
+
+// SetUnitResource sets the resource metadata for a specific unit.
+func (st *ResourceState) SetUnitResource(ctx context.Context, config resource.SetUnitResourceArgs) (resource.SetUnitResourceResult, error) {
+	return resource.SetUnitResourceResult{}, nil
+}
+
+// OpenApplicationResource returns the metadata for a resource.
+func (st *ResourceState) OpenApplicationResource(ctx context.Context, resourceID resources.ID) (resource.Resource, error) {
+	return resource.Resource{}, nil
+}
+
+// OpenUnitResource returns the metadata for a resource. A unit
+// resource is created to track the given unit and which resource
+// its using.
+func (st *ResourceState) OpenUnitResource(ctx context.Context, resourceID resources.ID, unitID coreunit.UUID) (resource.Resource, error) {
+	return resource.Resource{}, nil
+}
+
+// SetRepositoryResources sets the "polled" resources for the
+// application to the provided values. The current data for this
+// application/resource combination will be overwritten.
+func (st *ResourceState) SetRepositoryResources(ctx context.Context, config resource.SetRepositoryResourcesArgs) error {
+	return nil
+}

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -399,11 +399,15 @@ func (s *watcherSuite) setupService(c *gc.C, factory domain.WatchableDBFactory) 
 		state.NewCharmState(func() (database.TxnRunner, error) {
 			return s.ModelTxnRunner(), nil
 		}),
+		state.NewResourceState(func() (database.TxnRunner, error) { return s.ModelTxnRunner(), nil },
+			loggertesting.WrapCheckLog(c),
+		),
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
 		"", nil, nil,
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return provider.CommonStorageProviders()
 		}),
+		nil,
 		loggertesting.WrapCheckLog(c),
 	)
 }

--- a/domain/port/modelmigration/import.go
+++ b/domain/port/modelmigration/import.go
@@ -71,9 +71,11 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 		applicationstate.NewApplicationState(scope.ModelDB(), i.logger),
 		secretstate.NewState(scope.ModelDB(), i.logger),
 		applicationstate.NewCharmState(scope.ModelDB()),
+		nil, // Resources are not required for Port model migration.
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return storage.NotImplementedProviderRegistry{}
 		}),
+		nil, // Resources are not required for Port model migration.
 		i.logger,
 	)
 	return nil

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -57,11 +57,11 @@ VALUES (?, ?, ?, "test", "iaas", "fluffy", "ec2")
 func (s *watcherSuite) setupUnits(c *gc.C, appName string) {
 	logger := loggertesting.WrapCheckLog(c)
 	st := applicationstate.NewApplicationState(s.TxnRunnerFactory(), logger)
-	svc := applicationservice.NewService(st, nil, nil,
+	svc := applicationservice.NewService(st, nil, nil, nil,
 		corestorage.ConstModelStorageRegistry(func() storage.ProviderRegistry {
 			return storage.NotImplementedProviderRegistry{}
 		}),
-		logger,
+		nil, logger,
 	)
 
 	unitName, err := unit.NewNameFromParts(appName, 0)

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -175,11 +175,13 @@ func (s *ModelFactory) Application() *applicationservice.WatchableService {
 			s.logger.Child("application"),
 		),
 		applicationstate.NewCharmState(changestream.NewTxnRunnerFactory(s.modelDB)),
+		applicationstate.NewResourceState(changestream.NewTxnRunnerFactory(s.modelDB), s.logger.Child("resource")),
 		domain.NewWatcherFactory(s.modelDB, s.logger.Child("application")),
 		s.modelUUID,
 		modelagentstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		providertracker.ProviderRunner[applicationservice.Provider](s.providerFactory, s.modelUUID.String()),
 		s.storageRegistry,
+		s.objectstore,
 		s.logger.Child("application"),
 	)
 }

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -21,6 +21,7 @@ import (
 	agentprovisionerstate "github.com/juju/juju/domain/agentprovisioner/state"
 	annotationService "github.com/juju/juju/domain/annotation/service"
 	annotationState "github.com/juju/juju/domain/annotation/state"
+	"github.com/juju/juju/domain/application/resource"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	applicationstate "github.com/juju/juju/domain/application/state"
 	blockcommandservice "github.com/juju/juju/domain/blockcommand/service"
@@ -181,7 +182,7 @@ func (s *ModelFactory) Application() *applicationservice.WatchableService {
 		modelagentstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		providertracker.ProviderRunner[applicationservice.Provider](s.providerFactory, s.modelUUID.String()),
 		s.storageRegistry,
-		s.objectstore,
+		resource.NewResourceStoreFactory(s.objectstore),
 		s.logger.Child("application"),
 	)
 }


### PR DESCRIPTION
The service doesn't need to know about the object, it just cares that given a resource type, we get a store and using that store, we can then get a io.Reader. Talking about narrow types prevents us from using general types. This aids with testing and generalization.

We've removed coupling from a general type.